### PR TITLE
Enable fade-in animations for content

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,6 +49,8 @@ const prefersReduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').m
 =========================== */
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Enable animation-hiding rules immediately so elements can fade in
+  document.documentElement.classList.add('animate-init');
 
   const inViewport = (el, offset = 0.1) => {
     const r = el.getBoundingClientRect();
@@ -73,13 +75,10 @@ document.addEventListener('DOMContentLoaded', () => {
     targets.forEach(t => io.observe(t));
     return io;
   };
-/* ----- Generic reveals outside <section> ----- */
-const manualTargets = Array.from(document.querySelectorAll('.reveal, .reveal-p, .reveal-li'))
-.filter(el => !el.closest('section'));
-manualTargets.forEach(el => {
-if (inViewport(el, 0.1) || prefersReduced) el.classList.add('visible');
-});
-observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
+  /* ----- Generic reveals outside <section> ----- */
+  const manualTargets = Array.from(document.querySelectorAll('.reveal, .reveal-p, .reveal-li'))
+    .filter(el => !el.closest('section'));
+  observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
 
   /* ----- Cards (.fade-in) ----- */
   const cardTargets = Array.from(document.querySelectorAll('.fade-in'));
@@ -90,8 +89,6 @@ observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
       el.style.transitionDelay = `${i * 100}ms`;
     });
   }
-  // Pre-flag visible if already in view
-  cardTargets.forEach(el => { if (inViewport(el, 0.15) || prefersReduced) el.classList.add('visible'); });
   observe(cardTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
 
   /* ----- Section titles (all <h2>) ----- */
@@ -99,7 +96,6 @@ observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
   titles.forEach((t, i) => {
     t.classList.add('reveal');
     t.style.transitionDelay = `${i * 80}ms`;
-    if (inViewport(t, 0.15) || prefersReduced) t.classList.add('visible');
   });
   observe(titles, { threshold: 0.15, rootMargin: '0px 0px -10% 0px' });
 
@@ -111,7 +107,6 @@ observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
     paras.forEach((p, i) => {
       p.classList.add('reveal-p');
       p.style.transitionDelay = `${baseAfterH2 + (i * perParaDelay)}ms`;
-      if (inViewport(p, 0.1) || prefersReduced) p.classList.add('visible');
     });
     observe(paras, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
   });
@@ -127,7 +122,6 @@ observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
     bullets.forEach((li, i) => {
       li.classList.add('reveal-li');
       li.style.transitionDelay = `${baseAfterParas + (i * 90)}ms`;
-      if (inViewport(li, 0.08) || prefersReduced) li.classList.add('visible');
     });
     observe(bullets, { threshold: 0.08, rootMargin: '0px 0px -8% 0px' });
   });
@@ -135,17 +129,12 @@ observe(manualTargets, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
   /* ----- Hero image fade (if present) ----- */
   const heroImg = document.querySelector('.hero-media img.fade-hero');
   if (heroImg) {
-    if (inViewport(heroImg, 0.05) || prefersReduced) {
-      heroImg.classList.add('visible');
-    } else {
-      // nice entry on load
+    if (!inViewport(heroImg, 0.05)) {
+      // nice entry on load when not already in view
       heroImg.style.transitionDelay = '200ms';
     }
     observe([heroImg], { threshold: 0.05, rootMargin: '0px 0px -5% 0px' });
   }
-
-  // IMPORTANT: Only now enable animation-hiding rules
-  document.documentElement.classList.add('animate-init');
 });
 
 /* ===========================


### PR DESCRIPTION
## Summary
- Trigger `animate-init` on DOM ready so elements can fade in
- Use IntersectionObserver to fade in text, cards, and hero image as they appear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6225a53c83329c47fd4b867faa00